### PR TITLE
Add pre-commit hooks for local lint checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8


### PR DESCRIPTION
## Summary
Adds pre-commit configuration to catch lint issues at commit time.

## Changes
- `.pre-commit-config.yaml`: Configures hooks for trailing whitespace, mixed line endings, YAML validation, and flake8 linting.

## Impact
Developers who run `pre-commit install` will have lint issues caught before they push, preventing wasted CI runs on style violations.

Closes #3