### PR TITLE
Fix dispatch ref format for dependency check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
           REPO: ${{ github.repository }}
-          REF: ${{ github.ref }}
+          REF: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
         run: |
           gh api repos/calebjakemossey/assignment_example_ros_pkg/dispatches \


### PR DESCRIPTION
## Summary
Fixes the cross-repo dependency check trigger failing because of an incorrect ref format.

## Changes
Changed `github.ref` to `github.ref_name` in the dispatch payload. `github.ref` gives `refs/heads/main` but `git clone --branch` in the dependency-check workflow needs just `main`.

## Impact
The dependency check in assignment_example_ros_pkg will now successfully clone the upstream repo when triggered.

Closes #5