### PR TITLE
Remove cross-repo dispatch notification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,26 +20,3 @@ jobs:
     with:
       test-command: 'python -m pytest tests/'
       python-versions: '["3.10", "3.11", "3.12"]'
-
-  # Notify the ROS package repo when main changes so it can run a
-  # compatibility check against the latest version of this library.
-  # Requires the DISPATCH_TOKEN repository secret to be configured
-  # with a PAT that has repo scope on assignment_example_ros_pkg.
-  notify-downstream:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [ci]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger downstream compatibility check
-        env:
-          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
-          REPO: ${{ github.repository }}
-          REF: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-        run: |
-          gh api repos/calebjakemossey/assignment_example_ros_pkg/dispatches \
-            --method POST \
-            --field event_type=dependency-updated \
-            -f "client_payload[repo]=${REPO}" \
-            -f "client_payload[ref]=${REF}" \
-            -f "client_payload[sha]=${SHA}"


### PR DESCRIPTION
## Summary

Removes the `notify-downstream` job from CI because upstream repos should not hardcode knowledge of their downstreams - it couples repos together and doesn't scale.

## Changes

- Removed the `notify-downstream` job and its comments from `.github/workflows/ci.yaml`: this job sent a `repository_dispatch` to `assignment_example_ros_pkg` on every push to main, which is architecturally backwards - an upstream library shouldn't need to know which repos consume it.

## How compatibility is verified instead

Version bump PRs are the correct pattern. When `workspace.repos` is updated to pin a new upstream version, normal CI runs against that version and verifies compatibility. The downstream repo owns its dependency relationships.