### PR TITLE
Inline CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           pip install .
 
       - name: Run tests
-        run: python -m pytest tests/
+        run: python -m pytest tests/ --junitxml=test-results/results.xml
 
       - name: Publish test results
         uses: dorny/test-reporter@v1


### PR DESCRIPTION
## Summary

Replace the shared reusable workflow caller with an inline CI workflow, giving this repo full ownership of its build and test configuration.

## Changes

- **Replaced shared workflow call with inline jobs**: The previous CI called `python-ci.yaml@v1` from ci-workflows. Each package has different test requirements, so inlining the workflow removes the indirection and lets this repo control its own linting, test matrix, and result reporting directly.
- **Lint and test run as separate jobs**: Lint failures surface independently from test failures, making it clearer what needs fixing.
- **Multi-version test matrix retained**: Python 3.10, 3.11, and 3.12 are tested in parallel with `fail-fast: false` so all versions report results even if one fails.

## Notes

The shared release workflow in ci-workflows remains unchanged - it handles a genuinely unified release process across repos.

Closes #9