### PR TITLE
Update README with CI pipeline diagram and contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Example Package
 
-![CI](https://github.com/calebjakemossey/assignment_example_pkg/actions/workflows/ci.yaml/badge.svg)
+[![CI](https://github.com/calebjakemossey/assignment_example_pkg/actions/workflows/ci.yaml/badge.svg)](https://github.com/calebjakemossey/assignment_example_pkg/actions/workflows/ci.yaml)
 
-This is a ROS-independent Python package containing the `Example` class. It can be used separately from ROS for general-purpose applications.
+A ROS-independent Python package containing the `Example` class. It can be used separately from ROS for general-purpose applications.
 
 ## System Overview
 
@@ -17,12 +17,24 @@ graph LR
     B -->|uses messages from| C[example_package_msgs<br/>Service/Action Definitions]:::secondary
 ```
 
-> **Note on ROS2 distribution:** The original assignment referenced ROS2 Iron,
-> which reached end-of-life in December 2024. The CI pipeline targets ROS2
-> Humble (LTS, supported until May 2027).
+> **Note on ROS2 distribution:** The original assignment referenced ROS2 Iron, which reached end-of-life in December 2024. The CI pipeline targets ROS2 Humble (LTS, supported until May 2027).
 
-For details on the CI architecture and shared workflow design, see the
-[ci-workflows repository](https://github.com/calebjakemossey/ci-workflows).
+## CI Pipeline
+
+The CI workflow runs on every PR to `main` and every push to `main`. Lint gates the test matrix - tests do not start until linting passes.
+
+```mermaid
+%%{init: {'theme': 'dark', 'flowchart': {'curve': 'linear'}}}%%
+graph LR
+    classDef primary fill:#2d5986,stroke:#4a90d9,stroke-width:1px,color:#e0e0e0,rx:8,ry:8
+    classDef secondary fill:#1a3a5c,stroke:#3d7ab5,stroke-width:1px,color:#e0e0e0,rx:8,ry:8
+    classDef accent fill:#2d7d46,stroke:#4caf50,stroke-width:1px,color:#e0e0e0,rx:8,ry:8
+
+    LINT[Lint<br/>flake8]:::primary -->|pass| TEST[Test matrix<br/>Python 3.10 / 3.11 / 3.12]:::secondary
+    TEST --> RESULTS[Results on PR]:::accent
+```
+
+For details on the overall CI architecture and shared workflow design, see the [ci-workflows repository](https://github.com/calebjakemossey/ci-workflows).
 
 ## Dependencies
 
@@ -46,12 +58,12 @@ python3 -m venv venv
 source venv/bin/activate
 ```
 
-Once activated, your shell prompt should change to indicate you're in the virtual environment
+Once activated, your shell prompt should change to indicate you're in the virtual environment.
 Now you can install packages within this virtual environment.
 
 ### Install using `pip`
 
-```
+```bash
 # Navigate to the example_package directory
 cd example_package
 
@@ -62,7 +74,7 @@ pip install .
 This will install the `example_package` and its dependencies to the (virtual) environment.
 Alternatively, you can install the dependencies separately:
 
-```
+```bash
 # Install dependencies
 pip install -r requirements.txt
 
@@ -74,7 +86,7 @@ pip install .
 
 Alternatively, you can install the package using the `setup.py` script directly:
 
-```
+```bash
 # Navigate to the example_package directory
 cd example_package
 
@@ -86,7 +98,7 @@ python setup.py install
 
 After installation, you can import the `Example` class in your Python scripts and use it as follows:
 
-```
+```python
 from example_package.example import Example
 
 # Create an instance of the Example class with a custom message
@@ -104,7 +116,7 @@ print(ascii_art)
 **Sample Output of `get_ascii_art()`:**
 
 ```
- _   _      _ _                            _     _ _ 
+ _   _      _ _                            _     _ _
 | | | | ___| | | ___   __      _____  _ __| | __| | |
 | |_| |/ _ \ | |/ _ \  \ \ /\ / / _ \| '__| |/ _` | |
 |  _  |  __/ | | (_) |  \ V  V / (_) | |  | | (_| |_|
@@ -115,7 +127,7 @@ See also an example in [example_package/example_runner.py](example_package/examp
 
 Basic usage:
 
-```
+```bash
 example_runner "Your Message Here"
 ```
 
@@ -123,14 +135,14 @@ Display Message as ASCII Art:
 
 Use the `--ascii` flag to display the message as ASCII art.
 
-```
+```bash
 example_runner "Sunrise" --ascii
 ```
 
 **Sample Output:**
 
 ```
-/ ___| _   _ _ __  _ __(_)___  ___ 
+/ ___| _   _ _ __  _ __(_)___  ___
 \___ \| | | | '_ \| '__| / __|/ _ \
  ___) | |_| | | | | |  | \__ \  __/
 |____/ \__,_|_| |_|_|  |_|___/\___|
@@ -142,23 +154,17 @@ To ensure that the `Example` class is working correctly, you can run the unit te
 
 ### Running the Tests
 
-```
+```bash
 # Navigate to the example_package directory
 cd example_package
 
 # Activate the virtual environment if you created one
 source venv/bin/activate
 
-# Run the tests using the unittest module
-python -m unittest tests/test_example.py
+# Run the tests using pytest
+python -m pytest tests/
 ```
 
-**Expected Output:**
+## Contributing
 
-```
-..
-----------------------------------------------------------------------
-Ran 2 tests in 0.001s
-
-OK
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and PR workflow.


### PR DESCRIPTION
## Summary

Updates the README to include documentation that was missing for contributors - a CI pipeline diagram, a link to the contributing guide, and corrected test instructions.

## Changes

- **Add CI Pipeline section with mermaid diagram**: New contributors need to understand that linting gates the test matrix before tests run. The diagram visualises the sequential lint-then-test flow across Python 3.10/3.11/3.12.
- **Add Contributing section**: Links to CONTRIBUTING.md so the development workflow, PR process, and testing expectations are discoverable from the main README.
- **Update test instructions from `unittest` to `pytest`**: The CI workflow (`ci.yaml`) uses pytest, but the README previously instructed contributors to use `python -m unittest` - this mismatch could cause confusion when local results differ from CI.
- **Fix code fence language tags**: Adds `bash` and `python` language identifiers to fenced code blocks for proper syntax highlighting on GitHub.
- **Make CI badge clickable**: The badge now links to the Actions tab so build status is one click away.
- **Minor formatting fixes**: Trailing whitespace removed, missing full stops added.